### PR TITLE
Build to dist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
                 sh '''
                     node --version
                     npm --version
-                    test -f build/index.html
+                    test -f dist/index.html
                     npm test
                 '''
             }


### PR DESCRIPTION
This pull request includes a minor change to the `Jenkinsfile`. The change updates the file path checked during the build process from `build/index.html` to `dist/index.html`.

* [`Jenkinsfile`](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L43-R43): Modified the shell command to check for `dist/index.html` instead of `build/index.html` during the build process.