### PR TITLE
Deploy1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
                     node_modules/.bin/netlify --version  
                     echo "Deploying to Production. Site ID: $NETLIFY_SITE_ID"
                     node_modules/.bin/netlify status 
-                    node_modules/.bin/netlify deploy --dir=build --prod
+                    node_modules/.bin/netlify deploy --dir=dist --prod
                 '''
             }
         }


### PR DESCRIPTION
This pull request includes a small change to the `Jenkinsfile`. The change modifies the directory path used for deployment in the Netlify command.

* [`Jenkinsfile`](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L66-R66): Changed the deployment directory from `build` to `dist` in the Netlify deploy command.